### PR TITLE
Remove unnecessary CSS

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -1,15 +1,4 @@
 /* Buttons */
-
-.mode-interact .fl-widget-instance[data-name="Primary Button"] {
-  width: 100%;
-}
-
-@media (min-width:640px) {
-  .mode-interact .fl-widget-instance[data-name="Primary Button"] {
-    width: auto;
-  }
-}
-
 .btn-primary {
   display: block;
   clear: both;
@@ -36,11 +25,5 @@
     display: inline-block;
     width: auto;
     max-width: 100%;
-  }
-}
-
-@media only screen and (max-width: 640px) {
-  .fl-page-editable [data-fl-edit] [data-fl-widget-instance][data-name="Primary Button"] {
-    display: block;
   }
 }


### PR DESCRIPTION
- Removed unnecessary CSS because the new appearances will control these values.
```css
.mode-interact .fl-widget-instance[data-name="Primary Button"] {
  width: 100%;
}

@media (min-width:640px) {
  .mode-interact .fl-widget-instance[data-name="Primary Button"] {
    width: auto;
  }
}
```
The above will be controlled by the Appearance settings, we have set these values as the defaults in the theme config, but users can change them.

```css
@media only screen and (max-width: 640px) {
  .fl-page-editable [data-fl-edit] [data-fl-widget-instance][data-name="Primary Button"] {
    display: block;
  }
}
```
Same goes for this. This will still be the default, but users will be able to change this.

These were removed because the were being specifically targeted and overwriting the theme CSS.